### PR TITLE
Fix link to Alloy main site

### DIFF
--- a/tutorials/online/maintext-default.html
+++ b/tutorials/online/maintext-default.html
@@ -9,7 +9,7 @@
 
 <hr WIDTH="100%">
 
-<p> <a href="http://alloy.mit.edu/"
+<p> <a href="https://alloytools.org/"
     target="new"><i>Alloy</i></a> is a lightweight modelling language
     for software design. It is amenable to a fully automatic analysis,
     using the Alloy Analyzer, and provides a visualizer for making


### PR DESCRIPTION
The old link doesn't load