### PR TITLE
Fix release date of Alloy 6

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,5 +12,5 @@ Alloy is an open source language and analyzer for software modeling. It has been
 
 ## Alloy 6
 
-2011/11/04. [Alloy 6](alloy6.html) is a major [new release](https://alloytools.org/download.html) that adds mutable state, a temporal logic and accompanying solvers. Specifying the behavior of systems gets easier in many cases.
+2021/11/04. [Alloy 6](alloy6.html) is a major [new release](https://alloytools.org/download.html) that adds mutable state, a temporal logic and accompanying solvers. Specifying the behavior of systems gets easier in many cases.
 


### PR DESCRIPTION
According to [GitHub releases](https://github.com/AlloyTools/org.alloytools.alloy/releases/tag/v6.0.0), Alloy 6 was released a few weeks ago, not ten years ago.